### PR TITLE
Optimize  Where Expression

### DIFF
--- a/NiORM/NiORM.csproj
+++ b/NiORM/NiORM.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>ORM;SQL;Object-Relation;</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.6.0-beta</Version>
+    <Version>1.6.0-beta.1</Version>
 	  
     <PackageReleaseNotes>SECURITY UPDATE v1.5.0: Complete SQL injection protection with parameterized queries, automatic security validation, safe alternative methods (WhereMultiple, FindByProperty), security logging, and comprehensive protection guide. All existing methods now secure by default!</PackageReleaseNotes>
     <PackAsTool>False</PackAsTool>

--- a/NiORM/SQLServer/Core/Entities.cs
+++ b/NiORM/SQLServer/Core/Entities.cs
@@ -405,6 +405,13 @@ namespace NiORM.SQLServer.Core
                     var constExprString = ObjectDescriber<T, int>.ConvertToSqlFormat(constExpr.Value);
                     return constExprString;
 
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    // Handle type conversions (e.g., unwrapping nullable types like DateTime? to DateTime)
+                    // Just recursively process the inner expression
+                    var unaryExpr = (UnaryExpression)expression;
+                    return ExpressionToString(unaryExpr.Operand);
+
                 default:
                     throw new NotSupportedException($"Operation {expression.NodeType} is not supported.");
             }
@@ -483,6 +490,13 @@ namespace NiORM.SQLServer.Core
                 case ExpressionType.Constant:
                     var constExpr = (ConstantExpression)expression;
                     return ObjectDescriber<T, int>.ConvertToSqlFormat(constExpr.Value);
+
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    // Handle type conversions (e.g., unwrapping nullable types)
+                    // Just recursively process the inner expression
+                    var unaryExpr = (UnaryExpression)expression;
+                    return BuildMemberPath(unaryExpr.Operand, skipValue);
 
                 default:
                     // For other expression types, recursively process them


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves SQL translation of LINQ `Where(...)` predicates by properly handling type conversions.
> 
> - Add handling for `ExpressionType.Convert`/`ConvertChecked` in `ExpressionToString` and `BuildMemberPath` to unwrap nullable and cast expressions during SQL generation
> - Keeps existing special cases (e.g., `DateTime.Now`, `.Date`) working while improving robustness of expression parsing
> - Bump package version in `NiORM.csproj` to `1.6.0-beta.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2a155e3cec6914d4b3aa925d895e6af23271419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->